### PR TITLE
Adapter Option httpRoot und Filteroptionen in in Node zugefügt

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -115,16 +115,7 @@
         if (common.npmLibs){
             $('#libraries').val(common.npmLibs.join(', '));
         };
-        
-        if (common.httpRoot)
-          {
-            $('#httpRoot').val(common.httpRoot));
-          }
-         else
-          {
-            $('#httpRoot').val('/'));
-          };
-         
+                 
         $('#libraries').change(function () {
             onChange();
         }).keyup(function () {
@@ -176,7 +167,7 @@
             <td class="translate">Additional npm modules:</td><td><input id="libraries" class="value" style="width: 100%"/></td><td class="translate">Divided by comma</td>
         </tr>
         <tr>
-            <td class="translate">http root directory:</td><td><input id="httpRoot" class="value" style="width: 100%"/></td><td class="translate"></td>
+            <td class="translate">http root directory:</td><td><input id="httpRoot" class="value" style="width: 100%"/></td>
         </tr>
     </table>
     <h4 class="translate">node-red update select dialog</h4>

--- a/admin/index.html
+++ b/admin/index.html
@@ -148,7 +148,7 @@
             common.npmLibs.push(libs[l].trim());
         }
 
-        callback(obj, {localLink: 'http://%ip%:' + obj.httpRoot + obj.port, npmLibs: common.npmLibs});
+        callback(obj, {localLink: 'http://%ip%:' + obj.port, npmLibs: common.npmLibs});
     }
 </script>
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -55,6 +55,11 @@
             "en": "Additional npm modules:",
             "de": "Zusätzliche NPM-Module",
             "ru": "Дополнительные NPM Модули:"
+        },
+        "http root directory:": {
+            "en": "http root directory:",
+            "de": "http Stammpfad:",
+            "ru": "http root directory:"
         }
     };
 
@@ -109,8 +114,17 @@
 
         if (common.npmLibs){
             $('#libraries').val(common.npmLibs.join(', '));
-        }
-
+        };
+        
+        if (common.httpRoot)
+          {
+            $('#httpRoot').val(common.httpRoot));
+          }
+         else
+          {
+            $('#httpRoot').val('/'));
+          };
+         
         $('#libraries').change(function () {
             onChange();
         }).keyup(function () {
@@ -143,7 +157,7 @@
             common.npmLibs.push(libs[l].trim());
         }
 
-        callback(obj, {localLink: 'http://%ip%:' + obj.port, npmLibs: common.npmLibs});
+        callback(obj, {localLink: 'http://%ip%:' + obj.httpRoot + obj.port, npmLibs: common.npmLibs});
     }
 </script>
 
@@ -160,6 +174,9 @@
         <tr><td class="translate">Web server port:</td><td colspan="2"><input class="value number" id="port" type="input" size="5"/></td></tr>
         <tr>
             <td class="translate">Additional npm modules:</td><td><input id="libraries" class="value" style="width: 100%"/></td><td class="translate">Divided by comma</td>
+        </tr>
+        <tr>
+            <td class="translate">http root directory:</td><td><input id="httpRoot" class="value" style="width: 100%"/></td><td class="translate"></td>
         </tr>
     </table>
     <h4 class="translate">node-red update select dialog</h4>

--- a/admin/index.html
+++ b/admin/index.html
@@ -114,7 +114,7 @@
 
         if (common.npmLibs){
             $('#libraries').val(common.npmLibs.join(', '));
-        };
+        }
                  
         $('#libraries').change(function () {
             onChange();

--- a/io-package.json
+++ b/io-package.json
@@ -19,7 +19,7 @@
         "icon":                     "node-red.png",
         "keywords":                 ["node-red", "logic", "script"],
         "extIcon":                  "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/admin/node-red.png",
-        "localLink":                "http://%ip%:%port%",
+        "localLink":                "http://%ip%:%port%%httpRoot%",
         "enabled":                  true,
         "singletonHost":            true,
 		"supportStopInstance":      true,
@@ -27,11 +27,12 @@
         "readme":                   "https://github.com/ioBroker/ioBroker.node-red/blob/master/README.md",
         "stopBeforeUpdate":         true,
         "adminTab": {
-            "link":                 "http://%ip%:%port%"
+            "link":                 "http://%ip%:%port%%httpRoot%"
         }
     },
     "native": {
-        "port": 1880
+        "port": 1880,
+        "httpRoot": "/"
     },
     "objects": [
     ],

--- a/main.js
+++ b/main.js
@@ -221,6 +221,7 @@ function writeSettings() {
         lines[i] = setOption(lines[i], 'config', config);
         lines[i] = setOption(lines[i], 'functionGlobalContext', npms);
         lines[i] = setOption(lines[i], 'nodesdir', nodesDir);
+        lines[i] = setOption(lines[i], 'httpRoot');
     }
     fs.writeFileSync(userdataDir + 'settings.js', lines.join('\n'));
 }

--- a/nodes/ioBroker.html
+++ b/nodes/ioBroker.html
@@ -31,12 +31,31 @@
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
+    <div class="form-row">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-onlyack" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-onlyack" style="width: 70%;">Send only on then ack==true</label>
+    </div>
+    <div class="form-row">
+        <label for="node-input-func"><i class="fa fa-wrench"></i> Mode</label>
+        <select type="text" id="node-input-func" style="width:74%;">
+			<option value="all">Send all events</option>            
+            <option value="rbe">block unless value changes</option>
+            <option value="deadband">block unless changes by more than</option>
+		</select>
+    </div>
+    <div class="form-row" id="node-bandgap">
+        <label for="node-input-gap">&nbsp;</label>
+        <input type="text" id="node-input-gap" placeholder="e.g. 10 or 5%" style="width:71%;">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="ioBroker in">
     <p>ioBroker input node. Connects to a ioBroker and subscribes to the specified topic. The topic may contain redis wildcards (*).</p>
     <p>Outputs an object called <b>msg</b> containing <b>msg.topic, msg.payload, msg.timestamp, msg.lastchange and msg.acknowledged.</p>
-    <p><b>msg.payload</b> is a String.</p>
+	<p>The checkbox determines whether only States with ack == true or all events are forwarded.</p>
+	<p>The select box Mode offers further filtering options. The options are the same as for the RBE node.</p>
+	
 </script>
 <style type="text/css">
     /* --------------------------- ui.fancytree.min.css ----------------------------------------------------- */
@@ -1580,7 +1599,11 @@
         defaults: {
             name: {value:""},
             topic: {value:"*",required:true},
-            payloadType: {value:'value'}
+            payloadType: {value:'value'},
+			onlyack: {value:""},
+            func: {value:"all"},
+            gap: {value:"",validate:RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/)}
+ 			
         },
         color:"#a8bfd8",
         inputs:0,
@@ -1626,6 +1649,17 @@
                     }
                 });
             });
+             $("#node-input-func").on("change",function() {
+                if ($("#node-input-func").val() == null) $("#node-input-func").val ("all");
+				if ($("#node-input-func").val() === "deadband") {
+                    $("#node-bandgap").show();
+                } else {
+                    $("#node-bandgap").hide();
+                }
+            });
+			
+
+			
         }
     });
 </script>
@@ -1743,13 +1777,13 @@ RED.nodes.registerType('ioBroker out',{
         <label for="node-input-attrname"><i class="fa fa-tag"></i> Attribute</label>
         <input type="text" id="node-input-attrname" placeholder="attrname">
     </div>	
- 
-    <div class="form-tips">Tip: Leave topic blank if you want to set them via msg properties.</div>
+     <div class="form-tips">Tip: Leave topic blank if you want to set them via msg properties.</div>
 </script>
 
 <script type="text/x-red" data-help-name="ioBroker get">
     <p>Connects to a ioBroker and returns the requested value or the object in the massage attribute in the properties dialog, e.g. <b>msg.payload</b>. The object could be identified either by the <b>msg.topic</b> or specified in the poperties dialog. The value in the poperties dialog has precedence.</p>
     <p>The msg object also contains the attributs <b>msg.timestamp</b>, <b>msg.lastchange</b> and <b>msg.acknowledged</b>. All other attributes ob the input msg object will be passed to the output msg object.</p>
+ 
 </script>
 
 <script type="text/javascript">
@@ -1759,7 +1793,7 @@ RED.nodes.registerType('ioBroker get',{
             name: {value:""},
             topic: {value:""},
             attrname: {value:"payload"},
-           payloadType: {value:'value'}
+            payloadType: {value:'value'}
          },
         color:"#a8bfd8",
         inputs:1,
@@ -1806,7 +1840,9 @@ RED.nodes.registerType('ioBroker get',{
                     }
                 });
             });
-        }
+
+         }
+		
     });
 </script>
 

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -367,7 +367,7 @@ module.exports = function(RED) {
 					    {
 
                         if (!err && state) {
-                            node.msg [node.attrname]= obj.val.toString();
+                                                        node.msg [node.attrname]= (node.payloadType == 'object') ? state : (state.val === null || state.val === undefined) ? '' : state.val.toString();
 							node.msg.acknowledged=state.ack;
 							node.msg.timestamp=state.ts;
 							node.msg.lastchange=state.lc;

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -72,7 +72,18 @@ module.exports = function(RED) {
 
         node.regex = getRegex(this.topic);
         node.payloadType = n.payloadType;
+        node.onlyack=(n.onlyack==true || false);
+        node.func = n.func || "all";
+        node.gap = n.gap || "0";
+        node.pc = false;
+		if (node.gap.substr(-1) === "%") {
+            node.pc = true;
+            node.gap = parseFloat(node.gap);
+        }
+        node.g = node.gap;
 
+        node.previous = {};
+				
         if (node.topic) {
             var id = node.topic;
             // If no wildchars and belongs to this adapter
@@ -113,8 +124,42 @@ module.exports = function(RED) {
                 return;
             }
 
+			if (node.onlyack && obj.ack!=true) return;
+            
+			
+            var t = topic.replace(/\./g, '/') || "_no_topic";
+            //node.log ("Function: " + node.func);
+           
+			if (node.func === "rbe") 
+			  {
+              if (obj.val === node.previous[t])  
+			    {
+                return;             
+                };
+			  }
+             else if (node.func === "deadband") 
+			  {
+              var n = parseFloat(obj.val.toString());
+              if (!isNaN(n)) 
+			    {
+                //node.log ("Old Value: " + node.previous[t] + " New Value: " + n);
+				if (node.pc) { node.gap = (node.previous[t] * node.g / 100) || 0; }
+                if (!node.previous.hasOwnProperty(t)) { node.previous[t] = n - node.gap; }
+                if (!Math.abs(n - node.previous[t]) >= node.gap) 
+				  {
+                  return;
+                  }
+				}  
+               else 
+			    {
+                node.warn("no number found in value");
+                return;
+                }
+			  }
+            node.previous[t] = obj.val;
+			
             node.send({
-                topic:       topic.replace(/\./g, '/'),
+                topic:       t,
                 payload:     (node.payloadType == 'object') ? obj : (obj.val === null || obj.val === undefined) ? '' : obj.val.toString(),
                 acknowledged:obj.ack,
                 timestamp:   obj.ts,
@@ -284,7 +329,7 @@ module.exports = function(RED) {
         //node.regex = getRegex(this.topic);
         node.payloadType = n.payloadType;
         node.attrname = n.attrname;
-				
+
         if (node.topic) {
             var id = node.topic;
             // If no wildchars and belongs to this adapter
@@ -322,10 +367,11 @@ module.exports = function(RED) {
 					    {
 
                         if (!err && state) {
-                            node.msg [node.attrname]= state.val;
+                            node.msg [node.attrname]= obj.val.toString();
 							node.msg.acknowledged=state.ack;
 							node.msg.timestamp=state.ts;
 							node.msg.lastchange=state.lc;
+							node.send (node.msg);
 							
                         } else {
                             if (adapter.log) {
@@ -334,9 +380,7 @@ module.exports = function(RED) {
                                 console.log('State "' + id + '" does not exist in the ioBroker')
                             }
 
-						}
-		            node.wait=false;
-					node.send (node.msg);		
+						}		
                     };
 
        node.on("input", function(msg) {
@@ -357,7 +401,6 @@ module.exports = function(RED) {
                             console.log('Invalid topic name "' + id + '" for ioBroker');
                         }
                     } else {
- 					  node.wait=true;
 					  adapter.getState(id, node.getStateValue);
                     }
                 }

--- a/settings.js
+++ b/settings.js
@@ -91,7 +91,7 @@ module.exports = {
     
     // The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
     // to apply the same root to both parts.
-    httpRoot: '%%httpRoot%%',
+    httpRoot: "'%%httpRoot%%'",
     
     // The following property can be used in place of 'httpAdminAuth' and 'httpNodeAuth',
     // to apply the same authentication to both parts.

--- a/settings.js
+++ b/settings.js
@@ -91,7 +91,7 @@ module.exports = {
     
     // The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
     // to apply the same root to both parts.
-    //httpRoot: '/red',
+    httpRoot: '%%httpRoot%%',
     
     // The following property can be used in place of 'httpAdminAuth' and 'httpNodeAuth',
     // to apply the same authentication to both parts.


### PR DESCRIPTION
Im Adapter kann jetzt der node-red Paramter httpRoot gesetzt werden. Dies ist insbesondere hilfreich, wenn man den node-red editor über einen Reverse-Proxy zugänglich machen möchte, da ansonsten die socket.io Daten nicht weitergeleitet werden.

Im Node kann man nun nach folgenden Kriterien filtern:
- Nur Events mit ack==true
- Events unterdrücken nach den gleichen Kriterien wie im rbe Node

Eine  explizite Konvertierung des Datentyps war zwar angedacht, ergibt jedoch eigentlich nicht wirklich Sinn.