### PR TITLE
Add unsafe-perm option to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "https://github.com/ioBroker/ioBroker.node-red"
   },
+  "config": {
+    "unsafe-perm": true
+  },
   "optionalDependencies": {
     "js2xmlparser": "*",
     "fs.notify": "*",


### PR DESCRIPTION
Bestimmte Teile von node-red wie serialport werden nur korrekt installiert, wenn die Option unsafe-perm gesetzt wird. Diese wird nun für den Adapter gesetzt und hoffentlich an untergeordnete Packages vererbt.