### PR TITLE
Change to material icon

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -110,7 +110,7 @@
         "stopBeforeUpdate": true,
         "adminTab": {
             "link": "http://%ip%:%port%%httpRoot%",
-            "fa-icon": "fa-code-fork"
+            "fa-icon": "settings_input_composite"
         }
     },
     "native": {


### PR DESCRIPTION
Remnants of the FontAwesome have been eliminated. Added materialize icons for tab.