### PR TITLE
Create state name, role, type and readonly state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This adapter uses the node-red server from https://github.com/node-red/node-red
 **Note:** If in select ID dialog of the ioBroker node you cannot find some variable, restart node-red instance. By restarting the new list of objects will be created.
 
 ## Changelog
+### 1.13.2 (2019-11-24)
+* (SchumyHao) Set state name, role, type and readonly state in node and msg
+
 ### 1.13.1 (2019-10-23)
 * (RustyThePropellerHead) Logging elevated from debug to info for debug-nodes with console output 
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,9 +1,21 @@
 {
     "common": {
         "name": "node-red",
-        "version": "1.13.1",
+        "version": "1.13.2",
         "title": "node-red",
         "news": {
+            "1.13.2": {
+                "en": "Set state name, role, type and readonly state in node and msg",
+                "de": "Legen Sie den Statusnamen, die Rolle, den Typ und den schreibgeschützten Status in Node und msg fest",
+                "ru": "Установить имя состояния, роль, тип и состояние только для чтения в узле и сообщении",
+                "pt": "Definir nome do estado, função, tipo e estado somente leitura no nó e na mensagem",
+                "nl": "Stel de statusnaam, rol, type en alleen-lezen staat in knooppunt en msg",
+                "fr": "Définir le nom de l'état, le rôle, le type et l'état en lecture seule dans le noeud et le msg",
+                "it": "Imposta il nome dello stato, il ruolo, il tipo e lo stato di sola lettura nel nodo e nel messaggio",
+                "es": "Establezca el nombre del estado, el rol, el tipo y el estado de solo lectura en el nodo y el mensaje",
+                "pl": "Ustaw nazwę stanu, rolę, typ i stan tylko do odczytu w węźle i msg",
+                "zh-cn": "在节点和消息中设置状态名称，角色，类型和只读状态"
+            },
             "1.13.1": {
               "en": "Elevated logging for debug-nodes",
               "de": "Erhöhte Protokollierung für Debugknoten",

--- a/nodes/ioBroker.html
+++ b/nodes/ioBroker.html
@@ -166,6 +166,29 @@
             <option value="false">Ignore messages for non existing states</option>
         </select>
     </div>
+    <div class="form-row">
+        <label for="node-input-role"><i class="fa fa-tag"></i> Role</label>
+        <input type="text" id="node-input-role" placeholder="info">
+    </div>
+    <div class="form-row">
+        <label for="node-input-payloadType"><i class="fa fa-arrow-up"></i> Payload type</label>
+        <select id="node-input-payloadType" style="width:73% !important">
+            <option value="string">String</option>
+            <option value="number">Number</option>
+            <option value="boolean">Boolean</option>
+            <option value="array">Array</option>
+            <option value="object">Object</option>
+            <option value="mixed">Mixed</option>
+            <option value="file">File</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-readonly"><i class="fa fa-arrow-up"></i> Readonly</label>
+        <select id="node-input-readonly" style="width:73% !important">
+            <option value="true">Object is readonly</option>
+            <option value="false">Object is writeable</option>
+        </select>
+    </div>
     <div class="form-tips">Tip: Leave topic blank if you want to set them via msg properties.</div>
 </script>
 
@@ -173,6 +196,9 @@
     <p>Connects to a ioBroker and publishes <b>msg.payload</b> either to the <b>msg.topic</b> or to the topic specified in the edit window. The value in the edit window has precedence.</p>
     <p>If <b>msg.payload</b> contains an object it will be stringified before being sent.</p>
     <p>If <b>msg.payload</b> contains "__create__", the object will be only created, but no value will be written.</p>
+    <p>If <b>Role</b> is defined, the created object role will be set as this value. If <b>Role</b> is not defined, but <b>msg.role</b> is set, use this instead.</p>
+    <p>If <b>Payload type</b> is defined, the created object common type will be set as this value. If <b>Payload type</b> is not defined, but <b>msg.type</b> is set, use this instead. If both node and msg do not set type, the type will be type of payload</p>
+    <p>If <b>Readonly</b> is defined, the created object only readable. If <b>Readonly</b> is not defined, but <b>msg.readonly</b> is set, use this instead.</p>
 </script>
 
 <script type="text/javascript">
@@ -182,7 +208,10 @@ RED.nodes.registerType('ioBroker out',{
             name: {value:""},
             topic: {value:""},
             ack: {value:"false"},
-			autoCreate: {value: "false"}
+			autoCreate: {value: "false"},
+            role: {value:"info"},
+            payloadType: {value:"string"},
+            readonly: {value:"false"},
          },
         color:"#a8bfd8",
         inputs:1,

--- a/nodes/ioBroker.html
+++ b/nodes/ioBroker.html
@@ -167,6 +167,10 @@
         </select>
     </div>
     <div class="form-row">
+        <label for="node-input-stateName"><i class="fa fa-tag"></i> State Name</label>
+        <input type="text" id="node-input-stateName" placeholder="">
+    </div>
+    <div class="form-row">
         <label for="node-input-role"><i class="fa fa-tag"></i> Role</label>
         <input type="text" id="node-input-role" placeholder="info">
     </div>
@@ -196,6 +200,7 @@
     <p>Connects to a ioBroker and publishes <b>msg.payload</b> either to the <b>msg.topic</b> or to the topic specified in the edit window. The value in the edit window has precedence.</p>
     <p>If <b>msg.payload</b> contains an object it will be stringified before being sent.</p>
     <p>If <b>msg.payload</b> contains "__create__", the object will be only created, but no value will be written.</p>
+    <p>If <b>State Name</b> is defined, the created object name will be set as this value. If <b>State Name</b> is not defined, but <b>msg.stateName</b> is set, use this instead.  If both node and msg do not set state name, the name will same as topic</p>
     <p>If <b>Role</b> is defined, the created object role will be set as this value. If <b>Role</b> is not defined, but <b>msg.role</b> is set, use this instead.</p>
     <p>If <b>Payload type</b> is defined, the created object common type will be set as this value. If <b>Payload type</b> is not defined, but <b>msg.type</b> is set, use this instead. If both node and msg do not set type, the type will be type of payload</p>
     <p>If <b>Readonly</b> is defined, the created object only readable. If <b>Readonly</b> is not defined, but <b>msg.readonly</b> is set, use this instead.</p>
@@ -209,6 +214,7 @@ RED.nodes.registerType('ioBroker out',{
             topic: {value:""},
             ack: {value:"false"},
 			autoCreate: {value: "false"},
+            stateName: {value:"string"},
             role: {value:"info"},
             payloadType: {value:"string"},
             readonly: {value:"false"},

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -257,9 +257,9 @@ module.exports = function(RED) {
         node.ack = (n.ack === 'true' || n.ack === true);
         node.autoCreate = (n.autoCreate === 'true' || n.autoCreate === true);
         if (node.autoCreate) {
-            node.objectPreDefinedRole = n.objectPreDefinedRole;
-            node.objectPreDefinedType = n.objectPreDefinedType;
-            node.objectReadonly = n.objectReadonly || false;
+            node.objectPreDefinedRole = n.role;
+            node.objectPreDefinedType = n.payloadType;
+            node.objectReadonly = n.readonly || false;
         }
         node.regex = new RegExp('^node-red\\.' + instance + '\\.');
 

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -109,8 +109,10 @@ module.exports = function(RED) {
                         adapter.setObject(id, {
                             common: {
                                 name: id,
-                                role: 'info',
-                                type: 'state',
+                                role: node.objectPreDefinedRole || 'info',
+                                type: node.objectPreDefinedType || 'state',
+                                read: true,
+                                write: !node.objectReadonly,
                                 desc: 'Created by Node-Red'
                             },
                             native: {},
@@ -254,6 +256,11 @@ module.exports = function(RED) {
 
         node.ack = (n.ack === 'true' || n.ack === true);
         node.autoCreate = (n.autoCreate === 'true' || n.autoCreate === true);
+        if (node.autoCreate) {
+            node.objectPreDefinedRole = n.objectPreDefinedRole;
+            node.objectPreDefinedType = n.objectPreDefinedType;
+            node.objectReadonly = n.objectReadonly || false;
+        }
         node.regex = new RegExp('^node-red\\.' + instance + '\\.');
 
         if (ready) {
@@ -281,9 +288,11 @@ module.exports = function(RED) {
             }
             if (id) {
                 id = id.replace(/\//g, '.');
-
                 // Create variable if not exists
                 if (node.autoCreate && !node.idChecked) {
+                    node.objectPreDefinedRole = node.objectPreDefinedRole || msg.role
+                    node.objectReadonly = n.objectReadonly || msg.readonly;
+                    node.objectPreDefinedType = node.objectPreDefinedType || msg.type || typeof msg.payload
                     id = id.replace(/\//g, '.');
                     // If no wildchars and belongs to this adapter
                     if (id.indexOf('*') === -1 && (node.regex.test(id) || id.indexOf('.') !== -1)) {

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -108,7 +108,7 @@ module.exports = function(RED) {
                         // Create object
                         adapter.setObject(id, {
                             common: {
-                                name: id,
+                                name: node.objectPreDefinedName || id,
                                 role: node.objectPreDefinedRole || 'info',
                                 type: node.objectPreDefinedType || 'state',
                                 read: true,
@@ -259,6 +259,7 @@ module.exports = function(RED) {
         if (node.autoCreate) {
             node.objectPreDefinedRole = n.role;
             node.objectPreDefinedType = n.payloadType;
+            node.objectPreDefinedName = n.stateName || '';
             node.objectReadonly = n.readonly || false;
         }
         node.regex = new RegExp('^node-red\\.' + instance + '\\.');
@@ -293,6 +294,7 @@ module.exports = function(RED) {
                     node.objectPreDefinedRole = node.objectPreDefinedRole || msg.role
                     node.objectReadonly = n.objectReadonly || msg.readonly;
                     node.objectPreDefinedType = node.objectPreDefinedType || msg.type || typeof msg.payload
+                    node.objectPreDefinedName = n.stateName || msg.stateName || '';
                     id = id.replace(/\//g, '.');
                     // If no wildchars and belongs to this adapter
                     if (id.indexOf('*') === -1 && (node.regex.test(id) || id.indexOf('.') !== -1)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.node-red",
   "description": "This adapter uses node-red as a service of ioBroker. No additional node-red instance required.",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "author": {
     "name": "bluefox",
     "email": "dogafox@gmail.com"


### PR DESCRIPTION
User can set state name, role, type and readonly state in web UI and msg.
Do not need change it in admin page one more time any more.