### PR TITLE
Fix out node when using msg.topic

### DIFF
--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -281,7 +281,10 @@ module.exports = function(RED) {
         }
 
         node.on('input', function(msg) {
-            var id = node.topic || 'node-red.' + instance + '.' + msg.topic;
+            var id = node.topic || msg.topic;
+			if (!id.startsWith('node-red.' + instance + '.')) {
+				id = 'node-red.' + instance + '.' + id;
+			}
             if (!ready) {
                 nodeSets.push({'node': node, 'msg': msg});
                 //log('Message for "' + id + '" queued because ioBroker connection not initialized');

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -281,7 +281,7 @@ module.exports = function(RED) {
         }
 
         node.on('input', function(msg) {
-            var id = node.topic || msg.topic;
+            var id = node.topic || 'node-red.' + instance + '.' + msg.topic;
             if (!ready) {
                 nodeSets.push({'node': node, 'msg': msg});
                 //log('Message for "' + id + '" queued because ioBroker connection not initialized');


### PR DESCRIPTION
With this change (or another implementation) it is not possible to use `msg.topic` instead of the out nodes topic to store data in ioBroker.

A simple flow setup is as follows:
1. timestamp
1. function node
1. ioBroker out

## Not working case:
Set `msg.topic` inside the function node to i.e. `msg.topic = 'test/data'` (or `test.data`)

This case does not work, as into this else statement in the condition:
https://github.com/ioBroker/ioBroker.node-red/blob/master/nodes/ioBroker.js#L313

That is, because L306 leads to trying to set the foreign state, which does not work as the state (if not present) was created under `node-red.INSTANCE`.

## working case:
Setting topic through the ioBroker out node.

## Other implementation possiblity

While writing this, I thought about changing the state creation. I think that this situation is, because when I use the `msg.topic` case, the ioBroker state is ALWAYS created under `node-red.INSTANCE`. And then further on, the code thinks that this state should not be under `node-red.INSTANCE`.

I will create a second PR, which should be taken into account as well.