### PR TITLE
Update Node-Red to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "mongodb": "^3.5.4"
   },
   "dependencies": {
-    "node-red": "^1.0.4",
+    "node-red": "^1.0.6",
     "node-red-contrib-os": "^0.1.7",
-    "node-red-dashboard": "^2.19.4",
+    "node-red-dashboard": "^2.21.0",
     "node-red-contrib-aggregator": "^1.5.0",
     "node-red-contrib-polymer": "^0.0.22",
-    "node-red-node-email": "^1.7.7",
+    "node-red-node-email": "^1.7.8",
     "node-red-node-feedparser": "^0.1.15",
     "node-red-node-sentiment": "^0.1.6",
     "node-red-node-twitter": "^1.1.6",


### PR DESCRIPTION
Node-Red 1.0.6 is out. Updated node-red related dependencies to latest version. Fixing #100 
Note: I did not update other dependencies as I wasn't sure about the impact it might cause (e.g. @iobroker/adapter-core has been updated in the meantime)