### PR TITLE
Make palletmanager configurable and add warning about backups

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -142,6 +142,23 @@
         }
     }
 
+    function showHideBackupWarning() {
+        var $palletmanagerEnabled = $('#palletmanagerEnabled');
+        var $projectsEnabled = $('#projectsEnabled');
+
+        if($palletmanagerEnabled.prop('checked')) {
+            $('.npmModules').hide();
+        } else {
+            $('.npmModules').show();
+        }
+
+        if ($palletmanagerEnabled.prop('checked') || $projectsEnabled.prop('checked')) {
+            $('.backupWarn').show();
+        } else {
+            $('.backupWarn').hide();
+        }
+    }
+
     // the function loadSettings has to exist ...
     function load(settings, onChange) {
         if (!settings) return;
@@ -163,6 +180,9 @@
         }
         if (settings.projectsEnabled === undefined) {
             settings.projectsEnabled = false;
+        }
+        if (settings.palletmanagerEnabled === undefined) {
+            settings.palletmanagerEnabled = false;
         }
         oldPass = settings.pass;
         if (settings.pass) {
@@ -213,7 +233,18 @@
         fillSelectCertificates('#certPublic',  'public',  settings.certPublic);
         fillSelectCertificates('#certPrivate', 'private', settings.certPrivate);
 
+        $('#palletmanagerEnabled').on('change', function () {
+            showHideBackupWarning();
+            onChange();
+        });
+
+        $('#projectsEnabled').on('change', function () {
+            showHideBackupWarning();
+            onChange();
+        });
+
         showHideSettings();
+        showHideBackupWarning();
     }
 
     function save(callback) {
@@ -257,7 +288,20 @@
                     <img src="node-red.png" class="logo" alt="logo"/>
                 </div>
             </div>
+            <div class="row backupWarn">
+                <div class="col s12">
+                    <div class="card-panel red">
+                        <span class="white-text translate">Backups will not contain any projects or modules installed via the Palletmanager!</span>
+                    </div>
+                </div>
+            </div>
             <div class="row">
+                <div class="col s12 m4">
+                    <input class="value" id="palletmanagerEnabled" type="checkbox" />
+                    <label class="translate" for="palletmanagerEnabled">Use palletmanager:</label>
+                </div>
+            </div>
+            <div class="row npmModules">
                 <div class="input-field col s12 m8 l6">
                     <label class="translate">Additional npm modules:</label>
                     <div class="chips libraries"></div>

--- a/admin/words.js
+++ b/admin/words.js
@@ -52,5 +52,13 @@ systemDictionary = {
         "es": "Modo seguro",
         "pl": "Tryb bezpieczeństwa",
         "zh-cn": "安全模式"
+    },
+    "Use palletmanager:": {
+        "en": "Use palletmanager",
+        "de": "Palletenmanager benutzen"
+    },
+    "Backups will not contain any projects or modules installed via the Palletmanager": {
+        "en": "Backups will not contain any projects or modules installed via the Palletmanager!",
+        "de": "Backups enthalten keine Projekte und auch keine Module die mit dem Palletenmanager installiert sind."
     }
 };

--- a/io-package.json
+++ b/io-package.json
@@ -189,6 +189,7 @@
         "user": "",
         "pass": "",
         "projectsEnabled": false,
+        "palletmanagerEnabled": false,
         "allowCreationOfForeignObjects": false
     },
     "objects": [],

--- a/main.js
+++ b/main.js
@@ -318,6 +318,7 @@ function writeSettings() {
         lines[i] = setOption(lines[i], 'credentialSecret', secret);
         lines[i] = setOption(lines[i], 'valueConvert');
         lines[i] = setOption(lines[i], 'projectsEnabled', adapter.config.projectsEnabled);
+        lines[i] = setOption(lines[i], 'palletmanagerEnabled', adapter.config.palletmanagerEnabled);
         lines[i] = setOption(lines[i], 'allowCreationOfForeignObjects', adapter.config.allowCreationOfForeignObjects);
     }
 

--- a/main.js
+++ b/main.js
@@ -37,7 +37,6 @@ function startAdapter(options) {
     adapter = new utils.Adapter(options);
 
     adapter.on('message', obj => obj && obj.command && processMessage(obj));
-
     adapter.on('ready', () => installLibraries(main));
 
     return adapter;
@@ -70,11 +69,13 @@ function installNpm(npmLib, callback) {
 
 function installLibraries(callback) {
     let allInstalled = true;
+    
     if (typeof adapter.common.npmLibs === 'string') {
         adapter.common.npmLibs = adapter.common.npmLibs.split(/[,;\s]+/);
     }
 
-    if (adapter.common && adapter.common.npmLibs) {
+    if (adapter.common && adapter.common.npmLibs && !adapter.config.palletmanagerEnabled) {
+        adapter.log.error('install: ' + JSON.stringify(adapter.common.npmLibs));
         for (let lib = 0; lib < adapter.common.npmLibs.length; lib++) {
             if (adapter.common.npmLibs[lib] && adapter.common.npmLibs[lib].trim()) {
                 adapter.common.npmLibs[lib] = adapter.common.npmLibs[lib].trim();

--- a/settings.js
+++ b/settings.js
@@ -280,7 +280,7 @@ module.exports = {
             enabled: '%%projectsEnabled%%'
         },
         palette: {
-            editable: false
+            editable: '%%palletmanagerEnabled%%'
         }
     }
 };


### PR DESCRIPTION
Fixes #109 by adding a configuration setting to enable the palletmanager.

If the palletmanager or the project feature gets enabled then a warning will appear letting people know that if they use that settings a backup won't contain the modules and also won't contain the projects.

Maybe you can help me with the translations to check if they're correct? I used google translate