### PR TITLE
Topic format

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This adapter uses the node-red server from https://github.com/node-red/node-red
 -->
 
 ## Changelog
+### __WORK IN PROGRESS__
+* (Bannsaenger) added option for in Node to choose topic format (MQTTwith / or ioBroker with .). Default: MQTT
 ### 3.0.0 (2022-03-11)
 * IMPORTANT: Node-RED is now v2. Please check your nodes for compatibility! See also https://nodered.org/blog/2021/07/20/version-2-0-released and https://nodered.org/blog/2021/10/21/version-2-1-released
 * Detailed overview (in german): https://forum.iobroker.net/post/775767

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This adapter uses the node-red server from https://github.com/node-red/node-red
 
 ## Changelog
 ### __WORK IN PROGRESS__
-* (Bannsaenger) added option for in Node to choose topic format (MQTTwith / or ioBroker with .). Default: MQTT
+* (Bannsaenger) added option for in Node to choose topic format (MQTT with / or ioBroker with .). Default: MQTT
 ### 3.0.0 (2022-03-11)
 * IMPORTANT: Node-RED is now v2. Please check your nodes for compatibility! See also https://nodered.org/blog/2021/07/20/version-2-0-released and https://nodered.org/blog/2021/10/21/version-2-1-released
 * Detailed overview (in german): https://forum.iobroker.net/post/775767

--- a/nodes/ioBroker.html
+++ b/nodes/ioBroker.html
@@ -204,12 +204,20 @@
             <option value="false">send no message at start</option>
         </select>
     </div>
+    <div class="form-row">
+        <label for="node-input-outFormat"><i class="fa fa-arrow-up"></i> Topic format</label>
+        <select id="node-input-outFormat" style="width:73% !important">
+            <option value="MQTT">format topic to MQTT (with /)</option>
+            <option value="ioBroker">format topic to ioBroker (with .)</option>
+        </select>
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="ioBroker in">
     <p>ioBroker input node. Connects to a ioBroker and subscribes to the specified topic. The topic may contain redis wildcards (*).</p>
     <p>Outputs an object called <b>msg</b> containing <b>msg.topic, msg.payload, msg.timestamp, msg.lastchange</b> and <b>msg.acknowledged</b>.</p>
 	<p>The ack-flag determines whether only States with <i>ack == true</i>(updates) or <i>ack == false</i>(commands) or all events are forwarded.</p>
+    <p>In default the Node outputs the topic in MQTT format. This can be changed to the ioBroker database Format (with .)</p>
 	<p>The select box Mode offers further filtering options. The options are the same as for the RBE node.</p>
 </script>
 
@@ -223,7 +231,8 @@
 			onlyack: {value: ''},
             func: {value: 'all'},
             gap: {value: '', validate: RED.validators.regex(/^(\d*[.]*\d*|)(%|)$/)},
-            fireOnStart: {value: 'false'}
+            fireOnStart: {value: 'false'},
+            outFormat: {value: 'MQTT'}
         },
         color: '#a8bfd8',
         inputs: 0,

--- a/nodes/ioBroker.js
+++ b/nodes/ioBroker.js
@@ -329,6 +329,7 @@ module.exports = function (RED) {
         node.gap         = n.gap  || '0';
         node.gap         = n.gap  || '0';
         node.fireOnStart = n.fireOnStart === true || n.fireOnStart === 'true' || false;
+        node.outFormat   = n.outFormat || 'MQTT';
 
         if (n.onlyack === 'update') {
             node.onlyack = true;
@@ -400,7 +401,7 @@ module.exports = function (RED) {
             node.previous[t] = state ? state.val : null;
 
             node.send({
-                topic:        t,
+                topic:        node.outFormat === 'ioBroker' ? t.replace(/\//g, '.') : t,
                 payload:      node.payloadType === 'object' ? state : (!state || state.val === null || state.val === undefined ? '' : (valueConvert ? state.val.toString() : state.val)),
                 acknowledged: state ? state.ack  : false,
                 timestamp:    state ? state.ts   : Date.now(),


### PR DESCRIPTION
Let the user choose which topic format should be used in the in-Node.
All other nodes can be forced to use the ioBroker database format except the in-Node.