### PR TITLE
Added setting httpNodeRoot as httpRoot is not longer used in ioBroker.node-red version 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ This adapter uses the node-red server from https://github.com/node-red/node-red
 -->
 
 ## Changelog
+### 3.0.2 (2022-0x-xx)
+* (jwiesel) Added new parameter "httpNodeRoot" as httpRoot has been replaced by httpAdminRoot in version 3.0.0.
+
 ### 3.0.1 (2022-03-20)
-* (Bannsaenger) added option for in Node to choose topic format (MQTT with / or ioBroker with .). Default: MQTT
-*
+* (Bannsaenger) Added option for in Node to choose topic format (MQTT with / or ioBroker with .). Default: MQTT
 
 ### 3.0.0 (2022-03-11)
 * IMPORTANT: Node-RED is now v2. Please check your nodes for compatibility! See also https://nodered.org/blog/2021/07/20/version-2-0-released and https://nodered.org/blog/2021/10/21/version-2-1-released

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This adapter uses the node-red server from https://github.com/node-red/node-red
 -->
 
 ## Changelog
-### 3.0.2 (2022-0x-xx)
+### **WORK IN PROGRESS**
 * (jwiesel) Added new parameter "httpNodeRoot" as httpRoot has been replaced by httpAdminRoot in version 3.0.0.
 
 ### 3.0.1 (2022-03-20)

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -15,7 +15,8 @@
   "Use palletmanager:": "Palletenmanager benutzen",
   "User": "Benutzer",
   "Web server port:": "Webserver Port",
-  "http root directory:": "http Stammpfad",
+  "http Admin directory:": "http Admin Stammpfad",
+  "http Node directory:": "http Nodes Stammpfad",
   "node-red settings": "node-red Einstellungen",
   "node-red update select dialog": "node-red SelectID Dialog aktualisieren",
   "Do not read objects from admin": "Keine Objekte von admin lesen"

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -15,7 +15,8 @@
   "Use palletmanager:": "Use palletmanager",
   "User": "User",
   "Web server port:": "Web server port",
-  "http root directory:": "http root directory",
+  "http Admin directory:": "http Admin directory",
+  "http Node directory:": "http Node directory",
   "node-red settings": "node-red settings",
   "node-red update select dialog": "node-red update select dialog",
   "Do not read objects from admin": "Do not read objects from admin"

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "Utilice palletmanager",
   "User": "Usuario",
   "Web server port:": "Puerto del servidor web",
-  "http root directory:": "directorio raíz http",
+  "http Admin directory:": "directorio raíz http",
   "node-red settings": "configuración de node-red",
   "node-red update select dialog": "diálogo de selección de actualización node-red",
   "Do not read objects from admin": "No leer objetos del administrador"

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "Utiliser Palletmanager",
   "User": "Utilisateur",
   "Web server port:": "Port du serveur Web",
-  "http root directory:": "répertoire racine http",
+  "http Admin directory:": "répertoire racine http",
   "node-red settings": "paramètres de node-red",
   "node-red update select dialog": "boîte de dialogue de sélection de mise à jour de noeud",
   "Do not read objects from admin": "Ne pas lire les objets de l'administrateur"

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "Usa palletmanager",
   "User": "Utente",
   "Web server port:": "Porta del server Web",
-  "http root directory:": "directory root http",
+  "http Admin directory:": "directory root http",
   "node-red settings": "impostazioni del node-red",
   "node-red update select dialog": "finestra di dialogo di selezione aggiornamento node-red",
   "Do not read objects from admin": "Non leggere gli oggetti dall'amministratore"

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -15,7 +15,8 @@
   "Use palletmanager:": "Gebruik palletmanager",
   "User": "Gebruiker",
   "Web server port:": "Webserverpoort",
-  "http root directory:": "http root directory",
+  "http Admin directory:": "http Admin directory",
+  "http Node directory:": "http Node directory",
   "node-red settings": "node-red instellingen",
   "node-red update select dialog": "update select dialoogvenster",
   "Do not read objects from admin": "Lees geen objecten van admin"

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "Użyj menedżera palet",
   "User": "Użytkownik",
   "Web server port:": "Port serwera internetowego",
-  "http root directory:": "główny katalog http",
+  "http Admin directory:": "główny katalog http",
   "node-red settings": "ustawienia node-red",
   "node-red update select dialog": "okno dialogowe aktualizacji uaktualnienia węzła",
   "Do not read objects from admin": "Nie czytaj obiektów od administratora"

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "Use palletmanager",
   "User": "Do utilizador",
   "Web server port:": "Porta do servidor da Web",
-  "http root directory:": "diretório raiz http",
+  "http Admin directory:": "diretório raiz http",
   "node-red settings": "configurações de nó vermelho",
   "node-red update select dialog": "caixa de diálogo de seleção de atualização do nó-vermelho",
   "Do not read objects from admin": "Não leia objetos do administrador"

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -15,7 +15,8 @@
   "Use palletmanager:": "Использовать palletmanager",
   "User": "Пользователь",
   "Web server port:": "Порт веб сервера",
-  "http root directory:": "http root directory",
+  "http Admin directory:": "http Admin directory",
+  "http Node directory:": "http Node directory",
   "node-red settings": "Настройки node-red",
   "node-red update select dialog": "Обновить переменные в диалоге node-red",
   "Do not read objects from admin": "Не читать объекты из admin"

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -15,7 +15,7 @@
   "Use palletmanager:": "使用托盘管理器",
   "User": "用户",
   "Web server port:": "Web服务器端口",
-  "http root directory:": "http根目录",
+  "http Admin directory:": "http根目录",
   "node-red settings": "node-red设置",
   "node-red update select dialog": "node-red update选择对话框",
   "Do not read objects from admin": "不要从管理员读取对象"

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -353,9 +353,14 @@
             </div>
             <div class="row">
                 <div class="input-field col s12 m4 l3">
-                    <input id="httpRoot" class="value" type="text" style="width: 100%"/>
-                    <label class="translate" for="httpRoot">http root directory:</label>
-                    <span class="translate">(e.g. /admin)</span>
+                    <input id="httpAdminRoot" class="value" type="text" style="width: 100%"/>
+                    <label class="translate" for="httpAdminRoot">http Admin directory:</label>
+                    <span class="translate">Root directory for Node-RED (e.g. /admin)</span>
+                </div>
+                <div class="input-field col s12 m4 l3">
+                    <input id="httpNodeRoot" class="value" type="text" style="width: 100%"/>
+                    <label class="translate" for="httpNodeRoot">http Node directory:</label>
+                    <span class="translate">Root directory for HTTP Nodes and Dashboard (e.g. /)</span>
                 </div>
                 <div class="input-field col s12 m4 l3">
                     <input id="httpStatic" class="value" type="text" style="width: 100%"/>

--- a/io-package.json
+++ b/io-package.json
@@ -128,7 +128,7 @@
       "script"
     ],
     "extIcon": "https://raw.githubusercontent.com/ioBroker/ioBroker.node-red/master/admin/node-red.png",
-    "localLink": "http%s%://%ip%:%port%%httpRoot%",
+    "localLink": "http%s%://%ip%:%port%%httpAdminRoot%",
     "enabled": true,
     "singletonHost": true,
     "supportStopInstance": 3000,
@@ -139,7 +139,7 @@
     "readme": "https://github.com/ioBroker/ioBroker.node-red/blob/master/README.md",
     "stopBeforeUpdate": true,
     "adminTab": {
-      "link": "%protocol%://%ip%:%port%%httpRoot%",
+      "link": "%protocol%://%ip%:%port%%httpAdminRoot%",
       "fa-icon": "settings_input_composite"
     },
     "dependencies": [
@@ -157,7 +157,7 @@
     "secure": false,
     "certPublic": "",
     "certPrivate": "",
-    "httpRoot": "/",
+    "httpAdminRoot": "/",
     "hStatic": false,
     "httpStatic": "",
     "npmLibs": "",

--- a/main.js
+++ b/main.js
@@ -278,6 +278,7 @@ function writeSettings() {
     const secure = adapter.config.secure ? '' : '// ';
     const certFile = adapter.config.certPublic ? userDataDir + adapter.config.certPublic + '.crt' : '';
     const keyFile = adapter.config.certPrivate ? userDataDir + adapter.config.certPrivate + '.key' : '';
+    const hNodeRoot = adapter.config.httpNodeRoot ? adapter.config.httpNodeRoot : '/';
     const hStatic = adapter.config.hStatic === 'true' || adapter.config.hStatic === true ? '' : '// ';
 
     for (let a = 0; a < additional.length; a++) {
@@ -326,7 +327,8 @@ function writeSettings() {
         lines[i] = setOption(lines[i], 'config', config);
         lines[i] = setOption(lines[i], 'functionGlobalContext', npms);
         lines[i] = setOption(lines[i], 'nodesdir', nodesDir);
-        lines[i] = setOption(lines[i], 'httpRoot');
+        lines[i] = setOption(lines[i], 'httpAdminRoot');
+        lines[i] = setOption(lines[i], 'httpNodeRoot', hNodeRoot);
         lines[i] = setOption(lines[i], 'hStatic', hStatic);
         lines[i] = setOption(lines[i], 'httpStatic');
         lines[i] = setOption(lines[i], 'credentialSecret', secret);

--- a/settings.js
+++ b/settings.js
@@ -175,7 +175,7 @@ module.exports = {
      * If set to false, this is disabled.
      */
     //httpAdminRoot: '/admin',
-    httpAdminRoot: "'%%httpRoot%%'",
+    httpAdminRoot: "'%%httpAdminRoot%%'",
     /** httpRoot: "'%%httpRoot%%'", - has been deprecated: https://github.com/node-red/node-red/pull/2953 */
 
     /** The following property can be used to add a custom middleware function
@@ -195,7 +195,7 @@ module.exports = {
      * can be used to specifiy a different root path. If set to false, this is
      * disabled.
      */
-    //httpNodeRoot: '/red-nodes',
+    httpNodeRoot: "'%%httpNodeRoot%%'",
 
     /** The following property can be used to configure cross-origin resource sharing
      * in the HTTP nodes.


### PR DESCRIPTION
Fix for issue reported in version 3.0 in issue #288 

Solution approach:
* Add new parameter "httpNodeRoot" to ioBroker instance settings.
* If setting is not filled in instance setting, the default "/" is set on start of the instance (via main.js) 

URL for testing: https://github.com/jwiesel/ioBroker.node-red/archive/refs/heads/httpNodeRoot.zip