### PR TITLE
Add memory based context storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Instantiate the server with Node-RED
 ## Changelog
 ### **WORK IN PROGRESS**
 -   (@GermanBluefox) Allowed to use admin instance with authentication (Admin 7.6.4 is required)
+-   (thiloms) Add additional memory based context storage (memoryOnly).
 
 ### 6.0.8 (2025-03-24)
 -   (@GermanBluefox) Do not try to connect to unsecure admin from secure page and vice versa

--- a/settings.js
+++ b/settings.js
@@ -284,12 +284,13 @@ module.exports = {
           * Refer to the documentation for further options: https://nodered.org/docs/api/context/
           */
          contextStorage: {
-            default: {
-                module: "localfilesystem",
-                config: {
-                    dir: "'%%contextDir%%'"
-                }
-            }
+            default: "file",
+            memoryOnly: { module: "memory" },
+            file: { module: "localfilesystem",
+                    config: {
+                        dir: "'%%contextDir%%'"
+                    }
+                  }
          },
 
          /** `global.keys()` returns a list of all properties set in global context.


### PR DESCRIPTION
This change will add a memory based context storage.
Usually this is the default (see https://nodered.org/docs/user-guide/context) but the previous change of @klein0r implements file based context storage only.
The file based context storage is still the default but the user can also select a memory based context storage **memoryOnly** if required by some nodes configurations.